### PR TITLE
Add Umaishi Corporation staff hierarchy Codex page

### DIFF
--- a/codex/hierarchie-staff/index.html
+++ b/codex/hierarchie-staff/index.html
@@ -1,0 +1,321 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="icon" type="image/ico" href="https://ventistudio.fr/favicon.ico">
+  <title>Hiérarchie Staff – Umaishi Corporation</title>
+  <link rel="stylesheet" href="https://trust.ventistudio.fr/root/style.css">
+  <style>
+    .wiki-container {
+      max-width: 800px;
+      margin: 2rem auto;
+      padding: 0 2rem;
+    }
+    .wiki-content {
+      background: var(--bg-secondary);
+      padding: 2rem;
+      border-radius: 12px;
+      margin-bottom: 2rem;
+    }
+    .wiki-content h1 {
+      color: var(--accent);
+      margin-bottom: 1.5rem;
+      font-size: 2rem;
+    }
+    .wiki-content h2 {
+      color: var(--text-secondary);
+      margin: 2rem 0 1rem;
+      font-size: 1.5rem;
+    }
+    .wiki-content p {
+      margin-bottom: 1rem;
+      line-height: 1.7;
+    }
+    .wiki-content table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 1rem 0;
+      background: var(--bg-primary);
+      border-radius: 8px;
+      overflow: hidden;
+    }
+    .wiki-content th,
+    .wiki-content td {
+      padding: 0.75rem;
+      text-align: left;
+      border: 1px solid var(--border-color);
+    }
+    .wiki-content th {
+      background: var(--bg-secondary);
+      color: var(--accent);
+      font-weight: bold;
+    }
+    .wiki-content tr:hover {
+      background: var(--bg-hover);
+    }
+    .back-button {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      color: var(--text-primary);
+      text-decoration: none;
+      padding: 0.5rem 1rem;
+      border-radius: 4px;
+      transition: all 0.3s;
+      margin-bottom: 1rem;
+    }
+    .back-button:hover {
+      color: var(--accent);
+      background: rgba(var(--accent-rgb), 0.1);
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="logo">
+      <img src="https://ventistudio.fr/favicon.avif" alt="VentiStudio Logo" class="site-logo">
+      <span>VentiStudio</span>
+    </div>
+    <nav>
+      <a href="/">Accueil</a>
+      <a href="/approuvedcontent">Contenu Approuvé</a>
+      <a href="/player">Player</a>
+      <a href="/wiki">Wiki</a>
+      <a href="/staff">Staff</a>
+      <a href="/artist">Artiste</a>
+      <a href="/pip">PIP</a>
+    </nav>
+    <div class="controls">
+      <button id="theme-toggle" class="theme-toggle">
+        <svg width="24" height="24" viewBox="0 0 24 24">
+          <path class="sun" d="M12 3v2M12 19v2M5 12H3M21 12h-2M6 6l1.4 1.4M16.6 16.6L18 18M6 18l1.4-1.4M16.6 7.4L18 6" stroke="currentColor" fill="none"/>
+          <circle class="sun" cx="12" cy="12" r="4" stroke="currentColor" fill="none"/>
+          <path class="moon" d="M12 3a9 9 0 109 9c0-5-4-9-9-9z" stroke="currentColor" fill="none"/>
+        </svg>
+      </button>
+    </div>
+  </header>
+
+  <main>
+    <div class="wiki-container">
+      <a href="/umaishicorp" class="back-button">
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M19 12H5M12 19l-7-7 7-7"/>
+        </svg>
+        Retour à Umaishi Corp
+      </a>
+
+      <div class="wiki-content">
+        <h1>Hiérarchie Staff – Umaishi Corporation</h1>
+        <p>Cette page présente l’organisation interne de l’Umaishi Corporation. Chaque rôle au sein du staff possède des responsabilités précises, déterminées pour assurer un fonctionnement harmonieux des projets et de la communauté. Les catégories ci-dessous décrivent la logique de répartition ainsi que l’importance communautaire de chaque niveau.</p>
+
+        <h2>🧑‍💼 Staffs – Organisation Générale</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Grade Discord</th>
+              <th>Titre</th>
+              <th>Description courte</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>@🧑‍🎨 • Archon Primordiaux</td>
+              <td>Fondateur</td>
+              <td>Créateur originel de l’Umaishi Corp</td>
+            </tr>
+            <tr>
+              <td>@• Celestia •</td>
+              <td></td>
+              <td>Rang mystique à usage interne</td>
+            </tr>
+            <tr>
+              <td>@🧑‍🎨 • Archon Supérieur</td>
+              <td>Fondateur Adjoint</td>
+              <td>Soutien direct à la direction</td>
+            </tr>
+            <tr>
+              <td>@🧑‍🎨 • Archon Ambassadeur</td>
+              <td>Fondateur Ambassadeur</td>
+              <td>Représentant international</td>
+            </tr>
+            <tr>
+              <td>@🧑‍🎨 • Archon Héritiers</td>
+              <td>Responsable Global</td>
+              <td>Supervise l’ensemble des divisions</td>
+            </tr>
+            <tr>
+              <td>@🧑‍🎨 • Archon Porte Parole</td>
+              <td>Porte Parole</td>
+              <td>Chargé de la communication officielle</td>
+            </tr>
+            <tr>
+              <td>@• Les Sept •</td>
+              <td></td>
+              <td>Conseil stratégique symbolique</td>
+            </tr>
+            <tr>
+              <td>@🔧 • Archonte</td>
+              <td>Assistant des Fondateurs</td>
+              <td>Aide administrative centrale</td>
+            </tr>
+            <tr>
+              <td>@👔 • Adepte</td>
+              <td>Responsable Staff &amp; Avocat</td>
+              <td>Supervise le staff et intervient juridiquement</td>
+            </tr>
+            <tr>
+              <td>@✨ • Paimon</td>
+              <td>Ambassadrice Nasawa</td>
+              <td>Rôle unique pour une famille spéciale</td>
+            </tr>
+            <tr>
+              <td>@⚖️ • Shogun</td>
+              <td>Juge communautaire élu</td>
+              <td>Applique les règles lors des litiges</td>
+            </tr>
+            <tr>
+              <td>@🎗️ • Nahida</td>
+              <td>Aidant communautaire</td>
+              <td>Soutien moral, technique ou créatif</td>
+            </tr>
+            <tr>
+              <td>@💎 • Artefacts</td>
+              <td>Application Umaishi Corp</td>
+              <td>Entité IA ou logicielle rattachée</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <h2>👑 Chevaliers de l’Ordre – Modération</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Grade Discord</th>
+              <th>Titre</th>
+              <th>Rôle</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>@👑 • Grand Maître</td>
+              <td>Modérateur Lead</td>
+              <td>Gère les autres modérateurs</td>
+            </tr>
+            <tr>
+              <td>@⚔️ • Capitaine</td>
+              <td>Modérateur Senior</td>
+              <td>Modérateur expérimenté</td>
+            </tr>
+            <tr>
+              <td>@🛡️ • Chevalier</td>
+              <td>Modérateur</td>
+              <td>Modération quotidienne</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <h2>🪙 Membres Officiels – Créateurs &amp; Partenaires</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Grade Discord</th>
+              <th>Titre</th>
+              <th>Spécialité</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>@🎀 • Gei-Suka</td>
+              <td>Artiste Officiel</td>
+              <td>Illustrateurs, musiciens, créateurs visuels</td>
+            </tr>
+            <tr>
+              <td>@🏸 • Tsuman</td>
+              <td>Sportif Officiel</td>
+              <td>Membre reconnu pour ses performances sportives</td>
+            </tr>
+            <tr>
+              <td>@💫 • Stars Taiyo</td>
+              <td>Idol Officiel</td>
+              <td>Représentants artistiques inspirants</td>
+            </tr>
+            <tr>
+              <td>@🎮 • Game-Suka</td>
+              <td>Gamer Officiel</td>
+              <td>Influenceurs et joueurs partenaires</td>
+            </tr>
+            <tr>
+              <td>@🌐 • FiTsZ Haishin</td>
+              <td>Streamer Officiel</td>
+              <td>Diffuseurs officiels affiliés</td>
+            </tr>
+            <tr>
+              <td>@✨ • Ginga-Kage</td>
+              <td>Officiel Prestigieux</td>
+              <td>Talent d’exception dans un domaine spécifique</td>
+            </tr>
+            <tr>
+              <td>@🌍 • Hoshi-Jin</td>
+              <td>Associé Officiel</td>
+              <td>Partenaire ou auteur lié au lore VentiStudio</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <p><strong>Note :</strong> Chaque grade est lié à une fonction concrète dans la communauté, avec un niveau de confiance et de responsabilité évolutif. L’accès à certains rôles nécessite une validation manuelle par l’équipe fondatrice.</p>
+      </div>
+    </div>
+  </main>
+
+  <footer>
+    <div class="footer-content">
+      <div class="footer-section">
+        <h4>Outils</h4>
+        <ul>
+          <li><a href="/encrypt">Encrypt</a></li>
+          <li><a href="/sitemap">Sitemap</a></li>
+          <li><a href="https://status.ventistudio.fr/">Statut</a></li>
+          <li><a href="https://aina.ventistudio.fr/">Aina</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h4>Entreprise</h4>
+        <ul>
+          <li><a href="/about">À propos</a></li>
+          <li><a href="/jobs">Emplois</a></li>
+          <li><a href="/company">Marque</a></li>
+          <li><a href="/creator">Créateur</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h4>Ressources</h4>
+        <ul>
+          <li><a href="/university">Université</a></li>
+          <li><a href="/school">École</a></li>
+          <li><a href="/help">Assistance</a></li>
+          <li><a href="/security">Sécurité</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h4>Chartes</h4>
+        <ul>
+          <li><a href="/terms">Conditions</a></li>
+          <li><a href="/privacy">Confidentialité</a></li>
+          <li><a href="/cookies">Cookies</a></li>
+          <li><a href="/dmca">DMCA</a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="footer-bottom">
+      <p class="status">
+        <iframe src="https://status.ventistudio.fr/badge?theme=dark" width="250" height="30" frameborder="0" marginheight="0" marginwidth="0" scrolling="no"></iframe>
+      </p>
+      <p class="copyright">Copyright © P-Line 2023 - 2025. Tous droits réservés.</p>
+    </div>
+  </footer>
+
+  <script src="https://trust.ventistudio.fr/root/script.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add new Codex page describing staff hierarchy for Umaishi Corporation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842f1758484832bb79fd072f50251b0